### PR TITLE
Avoid loading libfixposix twice.

### DIFF
--- a/src/syscalls/ffi-functions-unix.lisp
+++ b/src/syscalls/ffi-functions-unix.lisp
@@ -12,7 +12,8 @@
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (define-foreign-library libfixposix
     (t (:default "libfixposix")))
-  (use-foreign-library libfixposix))
+  (unless (foreign-library-loaded-p 'libfixposix)
+    (use-foreign-library libfixposix)))
 
 
 


### PR DESCRIPTION
If a library is already loaded CFFI tries to unload it, which is not
implemented on ECL, causing errors during compilation.
