### PR TITLE
ecl: fix second value of %invoke

### DIFF
--- a/src/grovel/invoke.lisp
+++ b/src/grovel/invoke.lisp
@@ -59,12 +59,13 @@
 
 #+ecl
 (defun %invoke (command arglist)
-  (values
-   (nth-value 1 (ext:run-program "/bin/sh"
-                                 (list "-c"
-                                       (format nil "~A~{ ~A~}" command arglist))
-                                 :wait t :output nil :input nil :error nil))
-   "<see above>"))
+  (multiple-value-bind (output-stream exit-code)
+      (ext:run-program "/bin/sh"
+                       (list "-c"
+                             (format nil "~A~{ ~A~}" command arglist))
+                       :wait t :output :stream :input nil :error nil)
+    (values exit-code
+            (process-output output-stream))))
 
 #+(or openmcl cmu scl sbcl)
 (defun %invoke (command arglist)


### PR DESCRIPTION
same patch as issued to cffi