### PR TITLE
ecl/grovel: when adding c::*cc-flags* split the sequence

### DIFF
--- a/iolib.asd
+++ b/iolib.asd
@@ -88,7 +88,7 @@
   :version (:read-file-form "version.lisp-expr")
   :defsystem-depends-on (:iolib/asdf :iolib/conf)
   :depends-on (:iolib/asdf :iolib/conf
-               :alexandria #+allegro (:require "osi") :cffi :uiop)
+               :alexandria :split-sequence #+allegro (:require "osi") :cffi :uiop)
   :around-compile "iolib/asdf:compile-wrapper"
   :encoding :utf-8
   :pathname "src/grovel/"

--- a/src/grovel/grovel.lisp
+++ b/src/grovel/grovel.lisp
@@ -276,7 +276,8 @@ int main(int argc, char**argv) {
    #+darwin (list "-I" "/opt/local/include/")
    #-darwin nil
    ;; ECL internal flags
-   #+ecl (list c::*cc-flags*)
+   #+ecl (split-sequence:split-sequence #\space c::*cc-flags*
+                                        :remove-empty-subseqs t)
    ;; FreeBSD non-base header files
    ;; DragonFly Dports install software in /usr/local
    ;; And what about pkgsrc?


### PR DESCRIPTION
c::*cc-flags* is a string and adding it as-is caused grovel invocation
of g++ to break (ie " -Dxyz -D3" was treated as one argument).

Commit adds dependency on split-sequence and makes use of it in an
appropriate place.