### PR TITLE
Set *CXX* for FreeBSD correctly

### DIFF
--- a/src/grovel/grovel.lisp
+++ b/src/grovel/grovel.lisp
@@ -266,6 +266,8 @@ int main(int argc, char**argv) {
 
 
 (defparameter *cxx*
+  #+freebsd "clang++"
+  #-freebsd
   #+(or cygwin (not windows)) "g++"
   #+(and windows (not cygwin)) "c:/msys/1.0/bin/g++.exe")
 


### PR DESCRIPTION
Set c++ compiler for FreeBSD correctly, as there is no GCC in there by default