### PR TITLE
Better error capture & reporting

### DIFF
--- a/src/grovel/grovel.lisp
+++ b/src/grovel/grovel.lisp
@@ -46,13 +46,17 @@
     (setf command (cffi-sys:native-namestring command)))
   (format *debug-io* "; ~A~{ ~A~}~%" command args)
   (multiple-value-bind (output stderr exit-code)
-      (uiop:run-program (list* command args) :output :string)
-    (declare (ignore stderr))
+      (uiop:run-program (list* command args)
+                        :output :string
+                        :error-output :string
+                        ;; We'll throw our own error
+                        :ignore-error-status t)
     (unless (zerop exit-code)
       (grovel-error "External process exited with code ~S.~@
                      Command was: ~S~{ ~S~}~@
-                     Output was:~%~A"
-                    exit-code command args output))
+                     Output was:~%~A~@
+                     Error output was:~%~A"
+                    exit-code command args output stderr))
     output))
 
 ;;;# Error Conditions


### PR DESCRIPTION
When invoking external processes, the stderr is now captured and displayed, instead of just defaulting to a generic UIOP error about the exit code.

Most importantly, the lack of libfixposix now shows the actual g++ error, guiding the user as to what's wrong.