### PR TITLE
lpf_fd_isset should return lisp boolean

### DIFF
--- a/src/syscalls/ffi-functions-unix.lisp
+++ b/src/syscalls/ffi-functions-unix.lisp
@@ -538,7 +538,7 @@ Return two values: the file descriptor and the path of the temporary file."
   (fd     :int)
   (fd-set :pointer))
 
-(defcfun (fd-isset "lfp_fd_isset") bool
+(defcfun (fd-isset "lfp_fd_isset") :boolean
   (fd     :int)
   (fd-set :pointer))
 


### PR DESCRIPTION
Right now it returns 0 or 1 but in select backed it assumed to return nil or t.