### PR TITLE
Duplicated names in "IOLIB/COMMON-LISP-USER" defpackage: "IOLIB/COMMON-LISP-USER".

### DIFF
--- a/src/new-cl/pkgdcl.lisp
+++ b/src/new-cl/pkgdcl.lisp
@@ -47,5 +47,5 @@
   (define-gray-streams-package))
 
 (defpackage :iolib/common-lisp-user
-  (:nicknames :iolib/cl-user :iolib/common-lisp-user :iolib.cl-user)
+  (:nicknames :iolib/cl-user :iolib.cl-user)
   (:use :iolib/common-lisp))


### PR DESCRIPTION
Hi,

There's a small issue in the definition of "IOLIB/COMMON-LISP-USER" package: one of its nicknames is the same with the package name itself. Surprisingly it only broke IOlib build in LispWorks.

Regards,

Chun Tian (binghe)
