### PR TITLE
Make iolib work with ASDF 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
 
 script:
   - cl -e "(cl:in-package :cl-user)
-           (asdf:load-system :iolib/tests :verbose t)
+           (asdf:load-system :iolib.tests :verbose t)
            (uiop:quit (if (some (lambda (x) (typep x '5am::test-failure))
                                 (5am:run :iolib))
                           1 0))"

--- a/iolib.asd
+++ b/iolib.asd
@@ -3,98 +3,13 @@
 #.(unless (or #+asdf3.1 (version<= "3.1" (asdf-version)))
     (error "You need ASDF >= 3.1 to load this system correctly."))
 
-(defsystem :iolib/conf
-  :description "Compile-time configuration for IOLib."
-  :author "Stelian Ionescu <sionescu@cddr.org>"
-  :licence "MIT"
-  :version (:read-file-form "version.sexp")
-  :defsystem-depends-on (:iolib.asdf)
-  :around-compile "iolib/asdf:compile-wrapper"
-  :encoding :utf-8
-  :pathname "src/conf/"
-  :components
-  ((:file "pkgdcl")
-   (:file "requires" :depends-on ("pkgdcl"))))
-
-(defsystem :iolib/common-lisp
-  :description "Slightly modified Common Lisp."
-  :author "Stelian Ionescu <sionescu@cddr.org>"
-  :licence "MIT"
-  :version (:read-file-form "version.sexp")
-  :defsystem-depends-on (:iolib.asdf :iolib/conf)
-  :depends-on (:alexandria)
-  :around-compile "iolib/asdf:compile-wrapper"
-  :encoding :utf-8
-  :pathname "src/new-cl/"
-  :components
-  ((:file "conduits")
-   #+scl (:file "scl-gray-streams")
-   (:file "pkgdcl" :depends-on ("conduits" #+scl "scl-gray-streams")
-    :perform
-    (compile-op :before (o c)
-      (symbol-call :iolib/conf '#:load-gray-streams))
-    :perform
-    (load-op :before (o c)
-      (symbol-call :iolib/conf '#:load-gray-streams))
-    :perform
-    (load-source-op :before (o c)
-      (symbol-call :iolib/conf '#:load-gray-streams)))
-   (:file "gray-streams"
-    :depends-on ("pkgdcl" #+scl "scl-gray-streams"))
-   (:file "definitions" :depends-on ("pkgdcl"))
-   (:file "types" :depends-on ("pkgdcl"))))
-
-(defsystem :iolib/base
-  :description "Base IOlib package, used instead of CL."
-  :author "Stelian Ionescu <sionescu@cddr.org>"
-  :licence "MIT"
-  :version (:read-file-form "version.sexp")
-  :defsystem-depends-on (:iolib.asdf :iolib/conf)
-  :depends-on (:iolib/common-lisp :alexandria :split-sequence)
-  :around-compile "iolib/asdf:compile-wrapper"
-  :encoding :utf-8
-  :pathname "src/base/"
-  :components
-  ((:file "pkgdcl")
-   (:file "return-star" :depends-on ("pkgdcl"))
-   (:file "types" :depends-on ("pkgdcl" "return-star"))
-   (:file "debug" :depends-on ("pkgdcl" "return-star"))
-   (:file "conditions" :depends-on ("pkgdcl" "return-star"))
-   (:file "defalias" :depends-on ("pkgdcl" "return-star"))
-   (:file "deffoldable" :depends-on ("pkgdcl" "return-star"))
-   (:file "defobsolete" :depends-on ("pkgdcl" "return-star"))
-   (:file "reader" :depends-on ("pkgdcl" "return-star" "conditions"))
-   (:file "sequence" :depends-on ("pkgdcl" "return-star"))
-   (:file "matching" :depends-on ("pkgdcl" "return-star"))
-   (:file "time" :depends-on ("pkgdcl" "return-star"))
-   (:file "dynamic-buffer" :depends-on ("pkgdcl" "return-star" "sequence"))))
-
-(defsystem :iolib/grovel
-  :description "The CFFI Groveller"
-  :author "Dan Knapp <dankna@accela.net>"
-  :maintainer "Stelian Ionescu <sionescu@cddr.org>"
-  :licence "MIT"
-  :version (:read-file-form "version.sexp")
-  :defsystem-depends-on (:iolib.asdf :iolib/conf)
-  :depends-on (:iolib.asdf :iolib/base :iolib/conf
-               :alexandria :split-sequence #+allegro (:require "osi") :cffi :uiop)
-  :around-compile "iolib/asdf:compile-wrapper"
-  :encoding :utf-8
-  :pathname "src/grovel/"
-  :components
-  ((:file "package")
-   (:static-file "grovel-common.h")
-   (:file "grovel")
-   (:file "asdf"))
-  :serial t)
-
 (defsystem :iolib/syscalls
   :description "Syscalls and foreign types."
   :author "Stelian Ionescu <sionescu@cddr.org>"
   :licence "MIT"
   :version (:read-file-form "version.sexp")
-  :defsystem-depends-on (:iolib.asdf :iolib/conf :iolib/grovel)
-  :depends-on (:trivial-features :cffi :iolib/base :iolib/grovel)
+  :defsystem-depends-on (:iolib.asdf :iolib.conf :iolib.grovel)
+  :depends-on (:trivial-features :cffi :iolib.base :iolib.grovel)
   :around-compile "iolib/asdf:compile-wrapper"
   :encoding :utf-8
   :pathname "src/syscalls/"
@@ -116,8 +31,8 @@
   :author "Stelian Ionescu <sionescu@cddr.org>"
   :licence "MIT"
   :version (:read-file-form "version.sexp")
-  :defsystem-depends-on (:iolib.asdf :iolib/conf)
-  :depends-on (:iolib/base :iolib/syscalls :cffi)
+  :defsystem-depends-on (:iolib.asdf :iolib.conf)
+  :depends-on (:iolib.base :iolib/syscalls :cffi)
   :around-compile "iolib/asdf:compile-wrapper"
   :encoding :utf-8
   :pathname "src/multiplex/"
@@ -157,8 +72,8 @@
   :author "Stelian Ionescu <sionescu@cddr.org>"
   :licence "MIT"
   :version (:read-file-form "version.sexp")
-  :defsystem-depends-on (:iolib.asdf :iolib/conf)
-  :depends-on (:iolib/base :iolib/multiplex :cffi)
+  :defsystem-depends-on (:iolib.asdf :iolib.conf)
+  :depends-on (:iolib.base :iolib/multiplex :cffi)
   :around-compile "iolib/asdf:compile-wrapper"
   :encoding :utf-8
   :pathname "src/streams/gray/"
@@ -180,7 +95,7 @@
   :licence "MIT"
   :version (:read-file-form "version.sexp")
   :defsystem-depends-on (:iolib.asdf)
-  :depends-on (:iolib/base :iolib/syscalls :iolib/pathnames :cffi :bordeaux-threads)
+  :depends-on (:iolib.base :iolib/syscalls :iolib/pathnames :cffi :bordeaux-threads)
   :around-compile "iolib.asdf:compile-wrapper"
   :encoding :utf-8
   :pathname "src/streams/zeta/"
@@ -211,9 +126,9 @@
   :author "Stelian Ionescu <sionescu@cddr.org>"
   :licence "MIT"
   :version (:read-file-form "version.sexp")
-  :defsystem-depends-on (:iolib.asdf :iolib/conf :iolib/grovel)
-  :depends-on (:iolib/base :iolib/syscalls :iolib/streams
-               :babel :cffi :iolib/grovel :bordeaux-threads
+  :defsystem-depends-on (:iolib.asdf :iolib.conf :iolib.grovel)
+  :depends-on (:iolib.base :iolib/syscalls :iolib/streams
+               :babel :cffi :iolib.grovel :bordeaux-threads
                :idna :swap-bytes)
   :around-compile "iolib/asdf:compile-wrapper"
   :encoding :utf-8
@@ -279,8 +194,8 @@
   :maintainer "Stelian Ionescu <sionescu@cddr.org>"
   :licence "MIT"
   :version (:read-file-form "version.sexp")
-  :defsystem-depends-on (:iolib.asdf :iolib/conf)
-  :depends-on (:iolib/base :iolib/sockets)
+  :defsystem-depends-on (:iolib.asdf :iolib.conf)
+  :depends-on (:iolib.base :iolib/sockets)
   :around-compile "iolib/asdf:compile-wrapper"
   :encoding :utf-8
   :pathname "src/sockets/"
@@ -292,8 +207,8 @@
   :author "Stelian Ionescu <sionescu@cddr.org>"
   :licence "MIT"
   :version (:read-file-form "version.sexp")
-  :defsystem-depends-on (:iolib.asdf :iolib/conf)
-  :depends-on (:iolib/base :iolib/syscalls)
+  :defsystem-depends-on (:iolib.asdf :iolib.conf)
+  :depends-on (:iolib.base :iolib/syscalls)
   :around-compile "iolib/asdf:compile-wrapper"
   :encoding :utf-8
   :pathname "src/pathnames/"
@@ -308,8 +223,8 @@
   :author "Stelian Ionescu <sionescu@cddr.org>"
   :licence "MIT"
   :version (:read-file-form "version.sexp")
-  :defsystem-depends-on (:iolib.asdf :iolib/conf :iolib/grovel)
-  :depends-on (:iolib/base :iolib/grovel :iolib/syscalls
+  :defsystem-depends-on (:iolib.asdf :iolib.conf :iolib.grovel)
+  :depends-on (:iolib.base :iolib.grovel :iolib/syscalls
                :iolib/streams :iolib/pathnames)
   :around-compile "iolib/asdf:compile-wrapper"
   :encoding :utf-8
@@ -327,63 +242,10 @@
   :author "Stelian Ionescu <sionescu@cddr.org>"
   :licence "MIT"
   :version (:read-file-form "version.sexp")
-  :defsystem-depends-on (:iolib.asdf :iolib/conf)
-  :depends-on (:iolib/base :iolib/multiplex :iolib/streams :iolib/sockets)
+  :defsystem-depends-on (:iolib.asdf :iolib.conf)
+  :depends-on (:iolib.base :iolib/multiplex :iolib/streams :iolib/sockets)
   :around-compile "iolib/asdf:compile-wrapper"
   :encoding :utf-8
   :pathname "src/iolib/"
-  :components ((:file "pkgdcl")))
-
-(defmethod perform ((o test-op)
-                    (c (eql (find-system :iolib))))
-  (load-system :iolib/tests)
-  (symbol-call :5am :run! :iolib))
-
-(defsystem :iolib/tests
-  :description "IOLib test suite."
-  :author "Luis Oliveira <loliveira@common-lisp.net>"
-  :maintainer "Stelian Ionescu <sionescu@cddr.org>"
-  :licence "MIT"
-  :version (:read-file-form "version.sexp")
-  :defsystem-depends-on (:iolib/base)
-  :depends-on (:fiveam :iolib :iolib/pathnames)
-  :around-compile "iolib/asdf:compile-wrapper"
-  :encoding :utf-8
-  :pathname "tests/"
-  :components
-  ((:file "pkgdcl")
-   (:file "defsuites" :depends-on ("pkgdcl"))
-   (:file "base" :depends-on ("pkgdcl" "defsuites"))
-   (:file "file-paths-os" :depends-on ("pkgdcl" "defsuites")
-     :pathname #+unix "file-paths-unix")
-   (:file "events" :depends-on ("pkgdcl" "defsuites"))
-   (:file "streams" :depends-on ("pkgdcl" "defsuites"))
-   (:file "sockets" :depends-on ("pkgdcl" "defsuites"))))
-
-(defsystem :iolib/examples
-  :description "Examples for IOLib tutorial at http://pages.cs.wisc.edu/~psilord/blog/data/iolib-tutorial/tutorial.html"
-  :author "Peter Keller <psilord@cs.wisc.edu>"
-  :maintainer "Stelian Ionescu <sionescu@cddr.org>"
-  :licence "MIT"
-  :version (:read-file-form "version.sexp")
-  :defsystem-depends-on (:iolib/base)
-  :depends-on (:iolib :bordeaux-threads)
-  :around-compile "iolib/asdf:compile-wrapper"
-  :pathname "examples/"
-  :components ((:file "package")
-               (:file "ex1-client" :depends-on ("package"))
-               (:file "ex2-client" :depends-on ("package"))
-               (:file "ex3-client" :depends-on ("package"))
-               (:file "ex4-client" :depends-on ("package"))
-               (:file "ex5a-client" :depends-on ("package"))
-               (:file "ex5b-client" :depends-on ("package"))
-               (:file "ex1-server" :depends-on ("package"))
-               (:file "ex2-server" :depends-on ("package"))
-               (:file "ex3-server" :depends-on ("package"))
-               (:file "ex4-server" :depends-on ("package"))
-               (:file "ex5-server" :depends-on ("package"))
-               (:file "ex6-server" :depends-on ("package"))
-               (:file "ex7-buffer" :depends-on ("package"))
-               (:file "ex7-server" :depends-on ("package" "ex7-buffer"))
-               (:file "ex8-buffer" :depends-on ("package"))
-               (:file "ex8-server" :depends-on ("package" "ex8-buffer"))))
+  :components ((:file "pkgdcl"))
+  :in-order-to ((test-op (test-op :iolib.tests))))

--- a/iolib.base.asd
+++ b/iolib.base.asd
@@ -1,0 +1,26 @@
+;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+
+(defsystem :iolib.base
+  :description "Base IOlib package, used instead of CL."
+  :author "Stelian Ionescu <sionescu@cddr.org>"
+  :licence "MIT"
+  :version (:read-file-form "version.sexp")
+  :defsystem-depends-on (:iolib.asdf :iolib.conf)
+  :depends-on (:iolib.common-lisp :alexandria :split-sequence)
+  :around-compile "iolib/asdf:compile-wrapper"
+  :encoding :utf-8
+  :pathname "src/base/"
+  :components
+  ((:file "pkgdcl")
+   (:file "return-star" :depends-on ("pkgdcl"))
+   (:file "types" :depends-on ("pkgdcl" "return-star"))
+   (:file "debug" :depends-on ("pkgdcl" "return-star"))
+   (:file "conditions" :depends-on ("pkgdcl" "return-star"))
+   (:file "defalias" :depends-on ("pkgdcl" "return-star"))
+   (:file "deffoldable" :depends-on ("pkgdcl" "return-star"))
+   (:file "defobsolete" :depends-on ("pkgdcl" "return-star"))
+   (:file "reader" :depends-on ("pkgdcl" "return-star" "conditions"))
+   (:file "sequence" :depends-on ("pkgdcl" "return-star"))
+   (:file "matching" :depends-on ("pkgdcl" "return-star"))
+   (:file "time" :depends-on ("pkgdcl" "return-star"))
+   (:file "dynamic-buffer" :depends-on ("pkgdcl" "return-star" "sequence"))))

--- a/iolib.common-lisp.asd
+++ b/iolib.common-lisp.asd
@@ -1,0 +1,30 @@
+;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+
+(defsystem :iolib.common-lisp
+  :description "Slightly modified Common Lisp."
+  :author "Stelian Ionescu <sionescu@cddr.org>"
+  :licence "MIT"
+  :version (:read-file-form "version.sexp")
+  :defsystem-depends-on (:iolib.asdf :iolib.conf)
+  :depends-on (:alexandria)
+  :around-compile "iolib/asdf:compile-wrapper"
+  :encoding :utf-8
+  :pathname "src/new-cl/"
+  :components
+  ((:file "conduits")
+   #+scl (:file "scl-gray-streams")
+   (:file "pkgdcl" :depends-on ("conduits" #+scl "scl-gray-streams")
+    :perform
+    (compile-op :before (o c)
+      (symbol-call :iolib.conf '#:load-gray-streams))
+    :perform
+    (load-op :before (o c)
+      (symbol-call :iolib.conf '#:load-gray-streams))
+    :perform
+    (load-source-op :before (o c)
+      (symbol-call :iolib.conf '#:load-gray-streams)))
+   (:file "gray-streams"
+    :depends-on ("pkgdcl" #+scl "scl-gray-streams"))
+   (:file "definitions" :depends-on ("pkgdcl"))
+   (:file "types" :depends-on ("pkgdcl"))))
+

--- a/iolib.conf.asd
+++ b/iolib.conf.asd
@@ -1,0 +1,14 @@
+;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+
+(defsystem :iolib.conf
+  :description "Compile-time configuration for IOLib."
+  :author "Stelian Ionescu <sionescu@cddr.org>"
+  :licence "MIT"
+  :version (:read-file-form "version.sexp")
+  :defsystem-depends-on (:iolib.asdf)
+  :around-compile "iolib/asdf:compile-wrapper"
+  :encoding :utf-8
+  :pathname "src/conf/"
+  :components
+  ((:file "pkgdcl")
+   (:file "requires" :depends-on ("pkgdcl"))))

--- a/iolib.examples.asd
+++ b/iolib.examples.asd
@@ -1,0 +1,29 @@
+;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+
+(defsystem :iolib.examples
+  :description "Examples for IOLib tutorial at http://pages.cs.wisc.edu/~psilord/blog/data/iolib-tutorial/tutorial.html"
+  :author "Peter Keller <psilord@cs.wisc.edu>"
+  :maintainer "Stelian Ionescu <sionescu@cddr.org>"
+  :licence "MIT"
+  :version (:read-file-form "version.sexp")
+  :defsystem-depends-on (:iolib.base)
+  :depends-on (:iolib :bordeaux-threads)
+  :around-compile "iolib/asdf:compile-wrapper"
+  :pathname "examples/"
+  :components ((:file "package")
+               (:file "ex1-client" :depends-on ("package"))
+               (:file "ex2-client" :depends-on ("package"))
+               (:file "ex3-client" :depends-on ("package"))
+               (:file "ex4-client" :depends-on ("package"))
+               (:file "ex5a-client" :depends-on ("package"))
+               (:file "ex5b-client" :depends-on ("package"))
+               (:file "ex1-server" :depends-on ("package"))
+               (:file "ex2-server" :depends-on ("package"))
+               (:file "ex3-server" :depends-on ("package"))
+               (:file "ex4-server" :depends-on ("package"))
+               (:file "ex5-server" :depends-on ("package"))
+               (:file "ex6-server" :depends-on ("package"))
+               (:file "ex7-buffer" :depends-on ("package"))
+               (:file "ex7-server" :depends-on ("package" "ex7-buffer"))
+               (:file "ex8-buffer" :depends-on ("package"))
+               (:file "ex8-server" :depends-on ("package" "ex8-buffer"))))

--- a/iolib.grovel.asd
+++ b/iolib.grovel.asd
@@ -1,0 +1,20 @@
+;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+
+(defsystem :iolib.grovel
+  :description "The CFFI Groveller"
+  :author "Dan Knapp <dankna@accela.net>"
+  :maintainer "Stelian Ionescu <sionescu@cddr.org>"
+  :licence "MIT"
+  :version (:read-file-form "version.sexp")
+  :defsystem-depends-on (:iolib.asdf :iolib.conf)
+  :depends-on (:iolib.asdf :iolib.base :iolib.conf
+               :alexandria :split-sequence #+allegro (:require "osi") :cffi :uiop)
+  :around-compile "iolib/asdf:compile-wrapper"
+  :encoding :utf-8
+  :pathname "src/grovel/"
+  :components
+  ((:file "package")
+   (:static-file "grovel-common.h")
+   (:file "grovel")
+   (:file "asdf"))
+  :serial t)

--- a/iolib.tests.asd
+++ b/iolib.tests.asd
@@ -1,0 +1,23 @@
+;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+
+(defsystem :iolib.tests
+  :description "IOLib test suite."
+  :author "Luis Oliveira <loliveira@common-lisp.net>"
+  :maintainer "Stelian Ionescu <sionescu@cddr.org>"
+  :licence "MIT"
+  :version (:read-file-form "version.sexp")
+  :defsystem-depends-on (:iolib.base)
+  :depends-on (:fiveam :iolib :iolib/pathnames)
+  :around-compile "iolib/asdf:compile-wrapper"
+  :encoding :utf-8
+  :pathname "tests/"
+  :components
+  ((:file "pkgdcl")
+   (:file "defsuites" :depends-on ("pkgdcl"))
+   (:file "base" :depends-on ("pkgdcl" "defsuites"))
+   (:file "file-paths-os" :depends-on ("pkgdcl" "defsuites")
+     :pathname #+unix "file-paths-unix")
+   (:file "events" :depends-on ("pkgdcl" "defsuites"))
+   (:file "streams" :depends-on ("pkgdcl" "defsuites"))
+   (:file "sockets" :depends-on ("pkgdcl" "defsuites")))
+  :perform (test-op (o c) (symbol-call :5am :run! :iolib)))

--- a/src/grovel/grovel.lisp
+++ b/src/grovel/grovel.lisp
@@ -320,7 +320,7 @@ int main(int argc, char**argv) {
            ,(format nil "-I~A"
                     (directory-namestring
                      (asdf:component-pathname
-                      (asdf:find-system :iolib/grovel))))
+                      (asdf:find-system :iolib.grovel))))
            ,@(when library *platform-library-flags*)
            "-o" ,(native-namestring output-file)
            ,(native-namestring input-file))))

--- a/tests/sockets.lisp
+++ b/tests/sockets.lisp
@@ -382,7 +382,7 @@
   (is (string= (let ((file (namestring
                             (make-pathname :name "local-socket" :type nil
                                            :defaults (asdf:component-pathname
-                                                      (asdf:find-system :iolib/tests))))))
+                                                      (asdf:find-system :iolib.tests))))))
                  (ignore-errors (delete-file file))
                  (with-open-socket (p :address-family :local :connect :passive :local-filename file)
                    (with-open-socket (a :address-family :local :remote-filename file)

--- a/tests/streams.lisp
+++ b/tests/streams.lisp
@@ -75,7 +75,7 @@
 
 (defvar *data-dir*
   (let ((sys-pn (truename (asdf:component-pathname
-                           (asdf:find-system :iolib/tests)))))
+                           (asdf:find-system :iolib.tests)))))
     (make-pathname :directory (append (pathname-directory sys-pn)
                                       '("data")))))
 


### PR DESCRIPTION
Split iolib.asd into many files, because ASDF 3.3 insists in proper phase
separation whereby if a system is used in defsystem-depends-on it must be
in a separate .asd file. Keep the library subsystems themselves in iolib.asd.