### PR TITLE
Fixes for Solaris

### DIFF
--- a/src/sockets/grovel.lisp
+++ b/src/sockets/grovel.lisp
@@ -36,6 +36,8 @@
          #+linux "linux/netlink.h"
          "arpa/inet.h")
 
+#+(or sunos solaris) (cc-flags "-std=c99" "-D_POSIX_C_SOURCE=200112L" "-D__EXTENSIONS__")
+
 (in-package :iolib/sockets)
 
 (constantenum socket-error-values

--- a/src/syscalls/ffi-functions-unix.lisp
+++ b/src/syscalls/ffi-functions-unix.lisp
@@ -677,7 +677,8 @@ Return two values: the file descriptor and the path of the temporary file."
     (%readdir dir entry result)
     (if (null-pointer-p (mem-ref result :pointer))
         nil
-        (with-foreign-slots ((name type fileno) entry (:struct dirent))
+        #+(or sunos solaris) (cstring-to-sstring name)
+        #-(or sunos solaris) (with-foreign-slots ((name type fileno) entry (:struct dirent))
           (values (cstring-to-sstring name) type fileno)))))
 
 (defsyscall (rewinddir "rewinddir") :void

--- a/src/syscalls/ffi-types-unix.lisp
+++ b/src/syscalls/ffi-types-unix.lisp
@@ -462,8 +462,8 @@
 ;; point.
 (cstruct dirent "struct dirent"
   ;; POSIX actually requires this to be d_ino
-  (fileno "d_fileno" :type #-freebsd ino-t #+freebsd :uint32)
-  (type   "d_type"   :type :uint8)
+  #-(or sunos solaris) (fileno "d_fileno" :type #-freebsd ino-t #+freebsd :uint32)
+  #-(or sunos solaris) (type   "d_type"   :type :uint8)
   (name   "d_name"   :type :uint8 :count :auto))
 
 ;;; filetypes set in d_type slot of struct dirent


### PR DESCRIPTION
Solaris doesn't have d_fileno or d_type in the dirent struct and
also needs some cflags to avoid cffi grovel errors.