### PR TITLE
Update ex4-server.lisp

### DIFF
--- a/examples/ex4-server.lisp
+++ b/examples/ex4-server.lisp
@@ -60,7 +60,7 @@
               ;; ...and handle the connection!
               (when client
                 (make-thread #'process-ex4-client-thread
-                             :name 'process-ex4-client-thread))))
+                             :name "process-ex4-client-thread"))))
 
       ;; Clean up form for uw-p.
       ;; Clean up all of the client threads when done.


### PR DESCRIPTION
debugger invoked on a TYPE-ERROR in thread
#<THREAD "main thread" RUNNING {1001550EF3}>:
  The value
    PROCESS-EX4-CLIENT-THREAD
  is not of type
    STRING
  when binding SB-KERNEL::S

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [ABORT] Exit debugger, returning to top level.

(SB-INT:POSSIBLY-BASE-STRINGIZE PROCESS-EX4-CLIENT-THREAD) [external]
0]