### PR TITLE
Fix send-file-descriptor, receive-file-descriptor

### DIFF
--- a/src/sockets/grovel.lisp
+++ b/src/sockets/grovel.lisp
@@ -296,6 +296,10 @@
 (constant (msg-eor "MSG_EOR"))                        ; recvmsg sendmsg
 (constant (msg-ctrunc "MSG_CTRUNC"))                  ; recvmsg
 
+(cstruct iovec "struct iovec"
+  (base "iov_base" :type :pointer)
+  (len "iov_len" :type size-t))
+
 (cstruct msghdr "struct msghdr"
   (name       "msg_name"       :type :pointer)
   (namelen    "msg_namelen"    :type socklen-t)


### PR DESCRIPTION
The msghdr struct initialized no iovecs when preparing to send or
receive file descriptors. On my machine, when the
client calls `sendmsg()` with no iobuf, it succeeds (return val is not
-1), though the receiving side receives no message, therefore failing to
send a file descriptor.

I presume this is because it "optimizes" an "empty" message away as no message,
therefore still calling it a success.

This change initializes an iovec with a size of 1 byte, the bare minimum
required to create a successfully sending message.

Tested on Linux 5.10.10 x86_64

Essentially, the change would be synonymous with this C snippet:

```diff
+char nothing_name;
+struct iovec nothing_iov;
+iov.iov_base = &nothing_name;
+iov.iov_len = 1;

struct msghdr msg;
msg.msg_name = NULL;
msg.msg_namelen = 0;
+msg.msg_iov = &nothing_iov;
+msg.msg_iovlen = 1;
msg.msg_flags = 0;
msg.msg_control = cmsgbuf;
msg.msg_controllen = sizeof(cmsgbuf);

struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
cmsg->cmsg_level = SOL_SOCKET;
cmsg->cmsg_type = SCM_RIGHTS;
cmsg->cmsg_len = CMSG_LEN(sizeof(shm_fd));
memcpy(CMSG_DATA(cmsg), &shm_fd, sizeof(shm_fd));

// call fn...
```

Testing the C code before the changes verified that initializing a 1-byte iovec
was needed. Applying the changes to C fixed the issue and I've verified that
translating it back to iolib completed the fix.