### PR TITLE
libfixposix: fix include error on *BSD

### DIFF
--- a/src/os/ffi-types-unix.lisp
+++ b/src/os/ffi-types-unix.lisp
@@ -5,6 +5,10 @@
 
 (in-package :iolib/os)
 
+#+bsd
+(progn
+  (pkg-config-cflags "libfixposix"))
+
 (include "lfp.h")
 
 (constant (+stdin+  "STDIN_FILENO"))

--- a/src/syscalls/ffi-types-unix.lisp
+++ b/src/syscalls/ffi-types-unix.lisp
@@ -16,6 +16,10 @@
   (define "_LARGEFILE64_SOURCE")
   (define "_FILE_OFFSET_BITS" 64))
 
+#+bsd
+(progn
+  (pkg-config-cflags "libfixposix"))
+
 (include "lfp.h")
 
 (include "sys/poll.h" ;; FIXME: add poll() to LFP


### PR DESCRIPTION
The default include path for `cc` doesn't include `/usr/local` (where non-base packages/libraries are usually installed on BSDs).
The patch uses `pkgconf` to find `libfixposix` location, so `iolib` does not fail to build.